### PR TITLE
Redis keys for token should be "accountId.deviceId" instead only "dev…

### DIFF
--- a/api/data.ingestion.js
+++ b/api/data.ingestion.js
@@ -86,12 +86,14 @@ module.exports = function(logger) {
             //It set to set 0 since we do not want to enter to a loop
 
             var did = message.did;
+            var accountId = message.accountId;
+            var rediskey = accountId + "." + did;
             if (did === undefined || did === null) {
                 me.logger.error("Could not find DID in message.");
                 return;
             }
 
-            me.getToken(did)
+            me.getToken(rediskey)
             .then(function(token) {
                 if (token === null) {
                     return;

--- a/ingestion/mosquitto-auth/mosquitto_jwt_auth/jwt_auth_plugin/__init__.py
+++ b/ingestion/mosquitto-auth/mosquitto_jwt_auth/jwt_auth_plugin/__init__.py
@@ -126,10 +126,11 @@ def check_user_pass(deviceid, token):
       return 0 # auth failed
     else:
       print >> sys.stderr, "jwt_auth_plugin.py: Auth success for DeviceId =", deviceid, "; token_device_id =", token_device_id
-      r.hset(deviceid, "aid", tokenAccount)
-      r.hset(deviceid, "ciphertext", redisToken["ciphertext"])
-      r.hset(deviceid, "tag", redisToken["tag"])
-      r.hset(deviceid, "iv", redisToken["iv"])
+      redisKey = tokenAccount + "." + deviceid
+      r.hset(redisKey, "aid", tokenAccount)
+      r.hset(redisKey, "ciphertext", redisToken["ciphertext"])
+      r.hset(redisKey, "tag", redisToken["tag"])
+      r.hset(redisKey, "iv", redisToken["iv"])
       return 1
     #
   except:
@@ -152,9 +153,11 @@ def topic_acl(topic, deviceid):
        print >> sys.stderr, "jwt_auth_plugin.py: ACL allowed - deviceid is one for superuser!"
        return 1 # allow
 
-     aid = r.hget(deviceid, "aid")
-
-     if not aid:
+     parts = topic.split('/');
+     #aid = r.hget(deviceid, "aid")
+     aid = parts[2];
+     rediskey = aid + "." + deviceid
+     if not aid == r.hget(rediskey, "aid"):
       print >> sys.stderr, "jwt_auth_plugin.py: device not authenticated", deviceid
       return 0 #deny
      #


### PR DESCRIPTION
…iceId".

Reason: deviceId is not unique accross accounts. Closes #3

Signed-off-by: Marcel Wagner <wagmarcel@web.de>