### PR TITLE
change variable name on path builder from deviceId to did when submit…

### DIFF
--- a/api/def/device.def.js
+++ b/api/def/device.def.js
@@ -76,7 +76,7 @@ IoTKiT.DeviceComponentOption = DeviceComponentOption;
  * @constructor
  */
 function DeviceSubmitDataOption (data) {
-    this.pathname = common.buildPath(apiconf.path.submit.data, data.deviceId);
+    this.pathname = common.buildPath(apiconf.path.submit.data, data.did);
     ConnectionOptions.call(this);
     this.method = POST_METHOD;
     this.headers["Content-type"] = "application/json";


### PR DESCRIPTION
Replacing deviceId to did solve the problem of missing deviceId on path v1/api/data/{deviceId}

Signed-off-by: Gabrielle Poerwawinata <gabrielle.w.poerwawinata@intel.com>