### PR TITLE
Fix the submodule checkout problem in github actions

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -10,32 +10,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    env:
-      PLATFORMORG: Open-IoT-Service-Platform
     steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: Open-IoT-Service-Platform/platform-launcher.git
+        ref: 'develop'
+        path: platform-launcher
+        submodules: recursive
     - name: Setup main repo + subrepos
       shell: bash
       run: |
         export TERM=vt100
         sudo apt install jq
-        git clone https://github.com/${PLATFORMORG}/platform-launcher.git
         cd platform-launcher
-        git submodule update --recursive --init
         make update
-
-    - name: Checkout branch to test
-      working-directory: platform-launcher
-      shell: bash
-      run: |
-        export TERM=vt100
-        echo github repo: $GITHUB_REPOSITORY
-        REPO=${GITHUB_REPOSITORY##*/}
-        echo repo: $REPO
-        rm -rf ${REPO}
-        git clone https://github.com/${PLATFORMORG}/${REPO}.git
-        cd ${REPO}
-        git submodule update --recursive --init
-
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref }}
+        path: platform-launcher/oisp-mqtt-gw
     - name: Prepare platform
       shell: bash
       working-directory: platform-launcher

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -9,7 +9,9 @@ on:
       - '**-debugtest'
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    env:
+      SELF_HOSTED_RUNNER: true
+    runs-on: private
     steps:
     - uses: actions/checkout@v3
       with:
@@ -21,7 +23,9 @@ jobs:
       shell: bash
       run: |
         export TERM=vt100
-        sudo apt install jq
+        if [ -z "${SELF_HOSTED_RUNNER}" ]; then
+          sudo apt install jq
+        fi
         cd platform-launcher
         make update
     - uses: actions/checkout@v3
@@ -33,8 +37,12 @@ jobs:
       working-directory: platform-launcher
       run: |
         export TERM=vt100
-        cd util && \
-        bash setup-ubuntu20.04.sh
+        if [ -z "${SELF_HOSTED_RUNNER}" ]; then
+          cd util && \
+          bash setup-ubuntu20.04.sh
+        else
+          make restart-cluster
+        fi
 
     - name: Build platform
       working-directory: platform-launcher


### PR DESCRIPTION
Problem is caused by the recent change of submodule links
to ssh links. Without the use of actions/checkout the runner
needs a SSH key to checkout the submodules. The action
conveniently converts SSH links to HTTPS links for use with
github actions.

Closes #44 

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>